### PR TITLE
feat(auth): 添加记住我功能并增强安全性

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,9 @@ const express = require('express');
 const session = require('express-session');
 const favicon = require('serve-favicon');
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
 const path = require('path');
+const crypto = require('crypto');
 
 const app = express();
 const port = 3000;
@@ -10,6 +12,9 @@ const fs = require('fs');
 
 // 使用 body-parser 解析 POST 请求的 body
 app.use(bodyParser.urlencoded({ extended: true }));
+
+// 添加 cookie-parser 中间件
+app.use(cookieParser());
 
 // 提供静态文件 (CSS)
 app.use(express.static(path.join(__dirname, 'public')));
@@ -22,10 +27,39 @@ app.use(session({
   secret: 'The-strongest-secret-key-in-history',  // 设置 session 的 secret
   resave: false,  // 不允许重新保存未初始化的 session
   saveUninitialized: true, // 允许初始化未使用的 session
+  cookie: { secure: false } // 在生产环境中应设置为 true 以使用 HTTPS
 }));
 
 // 统一密码
 const correctPassword = process.env.PASSWORD || 'password';
+
+// 生成一个加密后的密码 cookie
+function generateHashedPassword(password) {
+  return crypto
+    .createHmac('sha256', 'The-strongest-secret-key-in-history')
+    .update(password)
+    .digest('hex');
+}
+
+// 检查用户是否已通过 cookie 登录的中间件
+app.use((req, res, next) => {
+  // 检查用户是否已在 session 中登录
+  if (!req.session.isLoggedIn) {
+    // 如果未登录，检查是否有有效的记住我 cookie
+    const storedHashedPassword = req.cookies.rememberedPassword;
+    
+    if (storedHashedPassword) {
+      const expectedHash = generateHashedPassword(correctPassword);
+      
+      // 验证 cookie 中的哈希值
+      if (storedHashedPassword === expectedHash) {
+        // cookie 有效，设置 session 登录状态
+        req.session.isLoggedIn = true;
+      }
+    }
+  }
+  next();
+});
 
 // 渲染登录页面
 app.get('/login', (req, res) => {
@@ -38,13 +72,40 @@ app.get('/login', (req, res) => {
 // 处理登录请求
 app.post('/login', (req, res) => {
   const password = req.body.password;
+  const rememberMe = req.body.rememberMe === 'on';
+  
   if (password === correctPassword) {
     // 登录成功，设置 session 标志
     req.session.isLoggedIn = true;
+    
+    // 如果用户选择了"记住我"选项，设置持久化 cookie
+    if (rememberMe) {
+      const hashedPassword = generateHashedPassword(password);
+      
+      // 设置长期有效的 cookie（30天）
+      res.cookie('rememberedPassword', hashedPassword, {
+        maxAge: 30 * 24 * 60 * 60 * 1000, // 30天有效期
+        httpOnly: true, // 防止客户端 JavaScript 访问
+        sameSite: 'strict' // 防止 CSRF 攻击
+      });
+    }
+    
     res.redirect('/note/1');
   } else {
     res.send('密码错误，请重新输入。<br><a href="/login">返回登录页</a>');
   }
+});
+
+// 退出登录
+app.get('/logout', (req, res) => {
+  // 清除 session
+  req.session.destroy();
+  
+  // 清除记住我 cookie
+  res.clearCookie('rememberedPassword');
+  
+  // 重定向到登录页
+  res.redirect('/login');
 });
 
 //渲染导航页

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -265,6 +265,21 @@ body {
   cursor: pointer;
 }
 
+.remember-me {
+  margin-bottom: 15px;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+}
+.remember-me input[type="checkbox"] {
+  margin-right: 8px;
+  cursor: pointer;
+}
+.remember-me label {
+  cursor: pointer;
+  color: #666;
+}
+
 /* 为用户添加的媒体查询，确保在非常小的屏幕上也保持可用性 */
 @media (max-width: 480px) {
   

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,6 +9,10 @@
 <body>
     <form action="/login" method="post" class="login-form">
         <input type="password" name="password" placeholder="请输入密码">
+        <div class="remember-me">
+            <input type="checkbox" id="rememberMe" name="rememberMe">
+            <label for="rememberMe">记住我（30天内自动登录）</label>
+        </div>
         <input type="submit" value="登录">
     </form>
     <script>


### PR DESCRIPTION
- 添加 cookie-parser 中间件以支持 cookie 操作
- 引入 crypto 模块以加密密码
- 实现生成加密密码的函数 generateHashedPassword
- 添加中间件检查用户登录状态，支持通过 cookie 自动登录
- 修改登录逻辑，支持记住我选项
- 添加 logout 功能，清除 session 和 cookie
- 更新登录页面，增加记住我复选框
- 调整样式，使记住我选项在视觉上更加协调